### PR TITLE
Add hashCode to TypeID

### DIFF
--- a/core/shared/src/main/scala/tech/ant8e/uuid4cats/TypeID.scala
+++ b/core/shared/src/main/scala/tech/ant8e/uuid4cats/TypeID.scala
@@ -202,6 +202,11 @@ object TypeID {
       case _             => false
     }
 
+    override def hashCode(): Int = {
+      val prime = 31
+      prime * (prime + prefix.hashCode) + uuid.hashCode
+    }
+
   }
 
   private[uuid4cats] def validatePrefix(

--- a/core/shared/src/test/scala/tech/ant8e/uuid4cats/TypeIDSuite.scala
+++ b/core/shared/src/test/scala/tech/ant8e/uuid4cats/TypeIDSuite.scala
@@ -259,6 +259,25 @@ class TypeIDSuite extends FunSuite {
     )
   }
 
+  test("TypeID should have a hashCode") {
+    // same id but different instances
+    val idString = "prefix_01h455vb4pex5vsknk084sn02q"
+    val id1_1 = TypeID.decode(idString).toOption.get
+    val id1_2 = TypeID.decode(idString).toOption.get
+    // other id
+    val id2 = TypeID.decode("prefix_01h455vb4pex5vsknk084sn02r").toOption.get
+    assertEquals(
+      List(
+        (id1_1, 1),
+        (id1_2, 3),
+        (id2, 5)
+      ).groupBy(_._1) // will group only when hashCode is the same
+        .map(_._2.map(_._2).sum)
+        .toSet,
+      Set(1 + 3, 5)
+    )
+  }
+
   private def assertValidEncoding(
       typeID: String,
       prefix: String,


### PR DESCRIPTION
Hi,

This PR adds a hashCode to TypeID so it can be used in hash maps and other objects relying on them.

Please, let me know if this PR needs some changes.

Regards,